### PR TITLE
WIP - Add const struct identifier support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Editor Directories
+.vscode/
+
 # Logs
 logs
 *.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,3 +16,4 @@
       "coverage.lcov": true
     },
     "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "description": "Generate TypeScript from Thrift IDL files",
     "main": "./dist/main/index.js",
     "types": "./dist/main/index.d.ts",
+    "engines": {
+        "hnvm": "13.9.0"
+    },
     "bin": {
         "thrift-typescript": "./dist/main/bin/index.js"
     },
@@ -13,7 +16,11 @@
     "scripts": {
         "clean": "rimraf ./dist ./**/codegen",
         "clean:all": "npm run clean && rimraf ./node_modules package-lock.json",
+        "clean:codegen": "rimraf ./**/codegen",
         "codegen": "node ./dist/main/bin/index.js --target apache --sourceDir ./src/tests/integration/thrift --outDir ./src/tests/integration/apache/codegen",
+        "codegen:debug": "node --inspect-brk ./dist/main/bin/index.js --target apache --sourceDir ./src/tests/integration/thrift --outDir ./src/tests/integration/apache/codegen",
+        "codegen:uc": "node ./dist/main/bin/index.js --target apache --sourceDir ../urbancompass/src/thrift/urbancompass --outDir ./src/tests/integration/apache/codegen",
+        "codegen:uc:debug": "node --inspect-brk ./dist/main/bin/index.js --target apache --sourceDir ../urbancompass/src/thrift/urbancompass --outDir ./src/tests/integration/apache/codegen",
         "prebuild": "npm run clean && npm run lint && npm run format",
         "build": "npm run build:only",
         "build:only": "tsc",

--- a/src/main/render/apache/index.ts
+++ b/src/main/render/apache/index.ts
@@ -48,11 +48,11 @@ export function renderImports(
         ..._renderIncludes(statements, state),
     ]
 
-    if (statementsUseThrift(statements)) {
+    if (statementsUseThrift(statements, state)) {
         includes.unshift(renderThriftImports(state.options.library))
     }
 
-    if (statementsUseInt64(statements)) {
+    if (statementsUseInt64(statements, state)) {
         includes.unshift(renderInt64Import())
     }
 

--- a/src/main/render/apache/interface.ts
+++ b/src/main/render/apache/interface.ts
@@ -14,7 +14,7 @@ import { renderOptional } from './utils'
  * Returns the name of the interface for the args arguments for a given struct-like object
  */
 export function interfaceNameForClass(statement: InterfaceWithFields): string {
-    return `I${statement.name.value}Args`
+    return `I${statement.name.value}__Args`
 }
 
 /**

--- a/src/main/render/apache/interface.ts
+++ b/src/main/render/apache/interface.ts
@@ -44,7 +44,7 @@ export function renderInterface(
             undefined,
             field.name.value,
             renderOptional(field.requiredness),
-            typeNodeForFieldType(field.fieldType, state, true),
+            typeNodeForFieldType(field.fieldType, state),
             undefined,
         )
     })

--- a/src/main/render/apache/service/utils.ts
+++ b/src/main/render/apache/service/utils.ts
@@ -7,11 +7,11 @@ export function capitalize(str: string): string {
 export function createStructArgsName(
     def: FunctionDefinition | FieldDefinition,
 ): string {
-    return `${capitalize(def.name.value)}Args`
+    return `${capitalize(def.name.value)}__Args`
 }
 
 export function createStructResultName(
     def: FunctionDefinition | FieldDefinition,
 ): string {
-    return `${capitalize(def.name.value)}Result`
+    return `${capitalize(def.name.value)}__Result`
 }

--- a/src/main/render/apache/values.ts
+++ b/src/main/render/apache/values.ts
@@ -157,9 +157,14 @@ function renderStruct(
     // need it. This adds it to the current namespace includes.
     // This should actually be done at the parser level. We only need to do it here because this is the first
     // recursive check run.
-    if (!state.currentNamespace.includedNamespaces[namespace.namespace.accessor]) {
-        state.currentNamespace.includedNamespaces[namespace.namespace.accessor] =
-            state.project.namespaces[namespace.namespace.accessor].namespace;
+    if (
+        state.currentNamespace.namespace.accessor !==
+            namespace.namespace.accessor &&
+        !state.currentNamespace.includedNamespaces[namespace.namespace.accessor]
+    ) {
+        state.currentNamespace.includedNamespaces[
+            namespace.namespace.accessor
+        ] = state.project.namespaces[namespace.namespace.accessor].namespace
     }
 
     const values = node.properties.map(({ name: propName, initializer }) => {

--- a/src/main/render/apache/values.ts
+++ b/src/main/render/apache/values.ts
@@ -152,6 +152,16 @@ function renderStruct(
     if (definition.type !== SyntaxType.StructDefinition) {
         throw new TypeError('Expected Struct Definition')
     }
+
+    // HACK(josh): If the recursively checked namespace is not part of the current namespace we may
+    // need it. This adds it to the current namespace includes.
+    // This should actually be done at the parser level. We only need to do it here because this is the first
+    // recursive check run.
+    if (!state.currentNamespace.includedNamespaces[namespace.namespace.accessor]) {
+        state.currentNamespace.includedNamespaces[namespace.namespace.accessor] =
+            state.project.namespaces[namespace.namespace.accessor].namespace;
+    }
+
     const values = node.properties.map(({ name: propName, initializer }) => {
         if (propName.type !== SyntaxType.StringLiteral) {
             throw new TypeError('Expected StringLiteral type')
@@ -174,7 +184,6 @@ function renderStruct(
             defFieldType = Resolver.resolveIdentifierWithAccessor(
                 defFieldType,
                 namespace,
-                fieldType,
                 state.currentNamespace,
             )
         }

--- a/src/main/render/shared/includes.ts
+++ b/src/main/render/shared/includes.ts
@@ -40,6 +40,15 @@ function fieldTypeUsesThrift(
                 namespaceMap: state.project.namespaces,
             })
 
+            // HACK(josh): If the recursively checked namespace is not part of the current namespace we may
+            // need it. This adds it to the current namespace includes.
+            // This should actually be done at the parser level. We only need to do it here because this is the first
+            // recursive check run.
+            if (!state.currentNamespace.includedNamespaces[namespace.namespace.accessor]) {
+                state.currentNamespace.includedNamespaces[namespace.namespace.accessor] =
+                    state.project.namespaces[namespace.namespace.accessor].namespace;
+            }
+
             if (definition.type === SyntaxType.StructDefinition) {
                 return definition.fields.some((fieldDef) => {
                     // HACK(josh): If the definition namespace is not part of an identifier

--- a/src/main/render/shared/includes.ts
+++ b/src/main/render/shared/includes.ts
@@ -44,9 +44,19 @@ function fieldTypeUsesThrift(
             // need it. This adds it to the current namespace includes.
             // This should actually be done at the parser level. We only need to do it here because this is the first
             // recursive check run.
-            if (!state.currentNamespace.includedNamespaces[namespace.namespace.accessor]) {
-                state.currentNamespace.includedNamespaces[namespace.namespace.accessor] =
-                    state.project.namespaces[namespace.namespace.accessor].namespace;
+            if (
+                state.currentNamespace.namespace.accessor !==
+                    namespace.namespace.accessor &&
+                !state.currentNamespace.includedNamespaces[
+                    namespace.namespace.accessor
+                ]
+            ) {
+                state.currentNamespace.includedNamespaces[
+                    namespace.namespace.accessor
+                ] =
+                    state.project.namespaces[
+                        namespace.namespace.accessor
+                    ].namespace
             }
 
             if (definition.type === SyntaxType.StructDefinition) {

--- a/src/main/render/shared/includes.ts
+++ b/src/main/render/shared/includes.ts
@@ -13,27 +13,64 @@ import { Resolver } from '../../resolver'
 import { DefinitionType, INamespacePath, IRenderState } from '../../types'
 import { COMMON_IDENTIFIERS } from './identifiers'
 
-function fieldTypeUsesThrift(fieldType: FieldType): boolean {
+function fieldTypeUsesThrift(
+    fieldType: FieldType,
+    state: IRenderState,
+): boolean {
     switch (fieldType.type) {
         case SyntaxType.I64Keyword:
             return true
 
         case SyntaxType.MapType:
             return (
-                fieldTypeUsesThrift(fieldType.keyType) ||
-                fieldTypeUsesThrift(fieldType.valueType)
+                fieldTypeUsesThrift(fieldType.keyType, state) ||
+                fieldTypeUsesThrift(fieldType.valueType, state)
             )
 
         case SyntaxType.ListType:
         case SyntaxType.SetType:
-            return fieldTypeUsesThrift(fieldType.valueType)
+            return fieldTypeUsesThrift(fieldType.valueType, state)
+        case SyntaxType.Identifier:
+            const {
+                definition,
+                namespace,
+            } = Resolver.resolveIdentifierDefinition(fieldType, {
+                currentNamespace: state.currentNamespace,
+                currentDefinitions: state.currentDefinitions,
+                namespaceMap: state.project.namespaces,
+            })
+
+            if (definition.type === SyntaxType.StructDefinition) {
+                return definition.fields.some((fieldDef) => {
+                    // HACK(josh): If the definition namespace is not part of an identifier
+                    // fieldtype we must stub it in for it to be referenced properly. This is
+                    // because of how resolveIdentifierDefinition works. There should be a better
+                    // way which preserves current namespace
+                    let { fieldType: defFieldType } = fieldDef
+                    if (defFieldType.type === SyntaxType.Identifier) {
+                        defFieldType = Resolver.resolveIdentifierWithAccessor(
+                            defFieldType,
+                            namespace,
+                            fieldType,
+                            state.currentNamespace,
+                        )
+                    }
+                    return (
+                        defFieldType.type !== SyntaxType.VoidKeyword &&
+                        fieldTypeUsesThrift(defFieldType, state)
+                    )
+                })
+            }
 
         default:
             return false
     }
 }
 
-function statementUsesThrift(statement: ThriftStatement): boolean {
+function statementUsesThrift(
+    statement: ThriftStatement,
+    state: IRenderState,
+): boolean {
     switch (statement.type) {
         case SyntaxType.StructDefinition:
         case SyntaxType.UnionDefinition:
@@ -48,10 +85,10 @@ function statementUsesThrift(statement: ThriftStatement): boolean {
             return false
 
         case SyntaxType.ConstDefinition:
-            return fieldTypeUsesThrift(statement.fieldType)
+            return fieldTypeUsesThrift(statement.fieldType, state)
 
         case SyntaxType.TypedefDefinition:
-            return fieldTypeUsesThrift(statement.definitionType)
+            return fieldTypeUsesThrift(statement.definitionType, state)
 
         default:
             const msg: never = statement
@@ -59,7 +96,10 @@ function statementUsesThrift(statement: ThriftStatement): boolean {
     }
 }
 
-function statementUsesInt64(statement: ThriftStatement): boolean {
+function statementUsesInt64(
+    statement: ThriftStatement,
+    state: IRenderState,
+): boolean {
     switch (statement.type) {
         case SyntaxType.ServiceDefinition:
             return statement.functions.some((func: FunctionDefinition) => {
@@ -90,10 +130,10 @@ function statementUsesInt64(statement: ThriftStatement): boolean {
             return false
 
         case SyntaxType.ConstDefinition:
-            return fieldTypeUsesThrift(statement.fieldType)
+            return fieldTypeUsesThrift(statement.fieldType, state)
 
         case SyntaxType.TypedefDefinition:
-            return fieldTypeUsesThrift(statement.definitionType)
+            return fieldTypeUsesThrift(statement.definitionType, state)
 
         default:
             const msg: never = statement
@@ -103,9 +143,10 @@ function statementUsesInt64(statement: ThriftStatement): boolean {
 
 export function statementsUseThrift(
     statements: Array<ThriftStatement>,
+    state: IRenderState,
 ): boolean {
     for (const statement of statements) {
-        if (statementUsesThrift(statement)) {
+        if (statementUsesThrift(statement, state)) {
             return true
         }
     }
@@ -115,9 +156,10 @@ export function statementsUseThrift(
 
 export function statementsUseInt64(
     statements: Array<ThriftStatement>,
+    state: IRenderState,
 ): boolean {
     for (const statement of statements) {
-        if (statementUsesInt64(statement)) {
+        if (statementUsesInt64(statement, state)) {
             return true
         }
     }

--- a/src/main/render/shared/includes.ts
+++ b/src/main/render/shared/includes.ts
@@ -51,7 +51,6 @@ function fieldTypeUsesThrift(
                         defFieldType = Resolver.resolveIdentifierWithAccessor(
                             defFieldType,
                             namespace,
-                            fieldType,
                             state.currentNamespace,
                         )
                     }

--- a/src/main/render/shared/includes.ts
+++ b/src/main/render/shared/includes.ts
@@ -135,7 +135,9 @@ function statementUsesInt64(
             })
 
         case SyntaxType.StructDefinition:
+            return true
         case SyntaxType.UnionDefinition:
+            return true
         case SyntaxType.ExceptionDefinition:
             return statement.fields.some((field: FieldDefinition) => {
                 return field.fieldType.type === SyntaxType.I64Keyword

--- a/src/main/render/thrift-server/index.ts
+++ b/src/main/render/thrift-server/index.ts
@@ -33,7 +33,7 @@ export function renderImports(
     statements: Array<ThriftStatement>,
     state: IRenderState,
 ): Array<ts.Statement> {
-    if (statementsUseThrift(statements)) {
+    if (statementsUseThrift(statements, state)) {
         return [
             renderThriftImports(state.options.library),
             ..._renderIncludes(statements, state),

--- a/src/main/resolver/identifiersForStatements.ts
+++ b/src/main/resolver/identifiersForStatements.ts
@@ -33,6 +33,15 @@ function identifiersForFieldType(
                 const definition = result.definition
                 const namespace = result.namespace
 
+                // HACK(josh): If the recursively checked namespace is not part of the current namespace we may
+                // need it. This adds it to the current namespace includes.
+                // This should actually be done at the parser level. We only need to do it here because this is the first
+                // recursive check run.
+                if (!context.currentNamespace.includedNamespaces[namespace.namespace.accessor]) {
+                    context.currentNamespace.includedNamespaces[namespace.namespace.accessor] =
+                        context.namespaceMap[namespace.namespace.accessor].namespace;
+                }
+
                 if (definition.type === SyntaxType.TypedefDefinition) {
                     identifiersForFieldType(
                         definition.definitionType,
@@ -75,6 +84,8 @@ function identifiersForFieldType(
                         }
                     }
                 }
+            } else {
+                results.add(fieldType.value)
             }
             break
 

--- a/src/main/resolver/identifiersForStatements.ts
+++ b/src/main/resolver/identifiersForStatements.ts
@@ -37,9 +37,19 @@ function identifiersForFieldType(
                 // need it. This adds it to the current namespace includes.
                 // This should actually be done at the parser level. We only need to do it here because this is the first
                 // recursive check run.
-                if (!context.currentNamespace.includedNamespaces[namespace.namespace.accessor]) {
-                    context.currentNamespace.includedNamespaces[namespace.namespace.accessor] =
-                        context.namespaceMap[namespace.namespace.accessor].namespace;
+                if (
+                    context.currentNamespace.namespace.accessor !==
+                        namespace.namespace.accessor &&
+                    !context.currentNamespace.includedNamespaces[
+                        namespace.namespace.accessor
+                    ]
+                ) {
+                    context.currentNamespace.includedNamespaces[
+                        namespace.namespace.accessor
+                    ] =
+                        context.namespaceMap[
+                            namespace.namespace.accessor
+                        ].namespace
                 }
 
                 if (definition.type === SyntaxType.TypedefDefinition) {

--- a/src/main/resolver/identifiersForStatements.ts
+++ b/src/main/resolver/identifiersForStatements.ts
@@ -54,7 +54,6 @@ function identifiersForFieldType(
                             defFieldType = resolveIdentifierWithAccessor(
                                 defFieldType,
                                 namespace,
-                                fieldType,
                                 context.currentNamespace,
                             )
 

--- a/src/main/resolver/index.ts
+++ b/src/main/resolver/index.ts
@@ -7,6 +7,7 @@ import { organizeByNamespace } from './organizeByNamespace'
 import { resolveConstValue } from './resolveConstValue'
 import { resolveIdentifierDefinition } from './resolveIdentifierDefinition'
 import { resolveIdentifierName } from './resolveIdentifierName'
+import { resolveIdentifierWithAccessor } from './resolveIdentifierWithAccessor'
 import { resolveNamespace } from './resolveNamespace'
 
 export const Resolver = {
@@ -19,5 +20,6 @@ export const Resolver = {
     resolveConstValue,
     resolveIdentifierName,
     resolveIdentifierDefinition,
+    resolveIdentifierWithAccessor,
     resolveNamespace,
 }

--- a/src/main/resolver/resolveIdentifierWithAccessor.ts
+++ b/src/main/resolver/resolveIdentifierWithAccessor.ts
@@ -1,0 +1,51 @@
+import { Identifier } from '@creditkarma/thrift-parser'
+
+import { INamespace } from '../types'
+import { stubIdentifier } from '../utils'
+
+/**
+ * Checks whether an Identifier is coming from another namespace or the current one. If it's from another
+ * then stub it with the proper accessor. If it's coming from the current then no stub necessary.
+ * @param id Id being checked
+ * @param idNamespace Namespace associated with id. Returned from resolveIdentifierDefinition()
+ * @param parentId Id of parent
+ * @param parentNamespace Namespace of the parent id
+ */
+export function resolveIdentifierWithAccessor(
+    id: Identifier,
+    idNamespace: INamespace,
+    parentId: Identifier,
+    parentNamespace: INamespace,
+): Identifier {
+    // Extract accessor from parent ID
+    const parentAccessor = parentId.value
+        .split('.')
+        .slice(0, -1)
+        .join('.')
+
+    // Only need to adjust id when id namespace is not in parent namespace
+    if (idNamespace.namespace.accessor !== parentNamespace.namespace.accessor) {
+        let newIdValue = id.value
+        // If the parent has an accessor that includes the id
+        if (
+            parentAccessor.length &&
+            parentAccessor.includes(idNamespace.namespace.accessor)
+        ) {
+            newIdValue = parentAccessor + '.' + newIdValue
+        } else if (parentAccessor.length) {
+            // If the parent has an accessor that doesnt include id
+            newIdValue =
+                parentAccessor +
+                '.' +
+                idNamespace.namespace.accessor +
+                '.' +
+                newIdValue
+        } else {
+            // If there is no parent accessor
+            newIdValue = idNamespace.namespace.accessor + '.' + newIdValue
+        }
+        return stubIdentifier(newIdValue)
+    }
+
+    return id
+}

--- a/src/main/resolver/resolveIdentifierWithAccessor.ts
+++ b/src/main/resolver/resolveIdentifierWithAccessor.ts
@@ -8,43 +8,17 @@ import { stubIdentifier } from '../utils'
  * then stub it with the proper accessor. If it's coming from the current then no stub necessary.
  * @param id Id being checked
  * @param idNamespace Namespace associated with id. Returned from resolveIdentifierDefinition()
- * @param parentId Id of parent
  * @param parentNamespace Namespace of the parent id
  */
 export function resolveIdentifierWithAccessor(
     id: Identifier,
     idNamespace: INamespace,
-    parentId: Identifier,
     parentNamespace: INamespace,
 ): Identifier {
-    // Extract accessor from parent ID
-    const parentAccessor = parentId.value
-        .split('.')
-        .slice(0, -1)
-        .join('.')
 
     // Only need to adjust id when id namespace is not in parent namespace
     if (idNamespace.namespace.accessor !== parentNamespace.namespace.accessor) {
-        let newIdValue = id.value
-        // If the parent has an accessor that includes the id
-        if (
-            parentAccessor.length &&
-            parentAccessor.includes(idNamespace.namespace.accessor)
-        ) {
-            newIdValue = parentAccessor + '.' + newIdValue
-        } else if (parentAccessor.length) {
-            // If the parent has an accessor that doesnt include id
-            newIdValue =
-                parentAccessor +
-                '.' +
-                idNamespace.namespace.accessor +
-                '.' +
-                newIdValue
-        } else {
-            // If there is no parent accessor
-            newIdValue = idNamespace.namespace.accessor + '.' + newIdValue
-        }
-        return stubIdentifier(newIdValue)
+        return stubIdentifier(idNamespace.namespace.accessor + '.' + id.value)
     }
 
     return id

--- a/src/main/resolver/resolveIdentifierWithAccessor.ts
+++ b/src/main/resolver/resolveIdentifierWithAccessor.ts
@@ -15,7 +15,6 @@ export function resolveIdentifierWithAccessor(
     idNamespace: INamespace,
     parentNamespace: INamespace,
 ): Identifier {
-
     // Only need to adjust id when id namespace is not in parent namespace
     if (idNamespace.namespace.accessor !== parentNamespace.namespace.accessor) {
         return stubIdentifier(idNamespace.namespace.accessor + '.' + id.value)

--- a/src/main/resolver/resolveNamespace.ts
+++ b/src/main/resolver/resolveNamespace.ts
@@ -37,7 +37,7 @@ import { resolveIdentifierDefinition } from './resolveIdentifierDefinition'
  *
  * 3. We need to rewrite the paths for imported identifiers.
  *
- *      For example, if a identifier is being imported from another file such as "operation.Operation", we
+ *      For example, if an identifier is being imported from another file such as "operation.Operation", we
  *      need to rewrite this so that the file path is replaced with the namespace path such as
  *      "com_test_operation.Operation"
  *

--- a/src/main/validator/index.ts
+++ b/src/main/validator/index.ts
@@ -176,6 +176,9 @@ export function validateNamespace(
                 break
 
             case SyntaxType.StructDefinition:
+                // TODO(josh): create validation for struct definitions
+                break
+
             case SyntaxType.UnionDefinition:
             case SyntaxType.ExceptionDefinition:
                 throw new ValidationError(

--- a/src/tests/integration/thrift/calculator.thrift
+++ b/src/tests/integration/thrift/calculator.thrift
@@ -19,6 +19,10 @@ struct Work {
   4: optional string comment,
 }
 
+struct Test {
+  1: CommonStruct common
+}
+
 struct FirstName {
   1: string name
 }

--- a/src/tests/integration/thrift/shared.thrift
+++ b/src/tests/integration/thrift/shared.thrift
@@ -9,6 +9,11 @@ struct SharedStruct {
   2: required string value
 }
 
+struct SharedSimpleStruct {
+  1: required bool sharedflag
+  2: required string sharedstring
+}
+
 union SharedUnion {
   1: string option1
   2: string option2

--- a/src/tests/integration/thrift/user.thrift
+++ b/src/tests/integration/thrift/user.thrift
@@ -1,8 +1,59 @@
 namespace java com.test.user
 namespace js com.test.user
 
+include "shared.thrift"
+include "common/common.thrift"
+include "calculator.thrift"
+
+typedef common.CommonStruct CommonStruct
+
+typedef calculator.Test TestStruct
+
+enum UserState {
+  LOGGED_IN = 1,
+  LOGGED_OUT = 2,
+}
+
+const User USER = {
+  "name": "Josh Stern",
+  "userSharedStruct": {
+    "sharedflag": true,
+    "sharedstring": "yada yada",
+  },
+  "state": UserState.LOGGED_IN,
+  "flag": true,
+  "common": {
+    "code": {
+      "status": 12
+    },
+    "value": "test value"
+  },
+  "subuser": {
+    "subname": "hello subuser"
+  },
+  "test": {
+    "common": {
+      "code": {
+        "status": 12
+      },
+      "value": "test value"
+    }
+  }
+}
+
+struct SubUser {
+  1: string subname
+}
+
 struct User {
   1: string name
+  2: shared.SharedSimpleStruct userSharedStruct
+  3: UserState state
+  4: bool flag
+  5: optional i64 opt
+  6: optional CommonStruct common
+  7: SubUser subuser
+  8: TestStruct test
 }
 
 service UserService {


### PR DESCRIPTION
This does not include the required changes for validation or namespace resolution. Should be
considered POC for using this tool in our codebase
Things to consider if we continue:
1. optional item special handling
2. depth of validation
3. Identifiers can have a definition of any type, I currently throw errors if the identifiers in my codepath are not StructDefinitions. This may need adjustment.