### PR TITLE
Update checks to remove redundancy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Editor Directories
-.vscode/
-
 # Logs
 logs
 *.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Codegen",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run",
+                "codegen:debug",
+                "--scripts-prepend-node-path"
+            ],
+            "port": 9229,
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Codegen UC",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run",
+                "codegen:uc:debug",
+                "--scripts-prepend-node-path"
+            ],
+            "port": 9229,
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        }
+    ]
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -158,9 +158,9 @@ export function thriftProjectFromSourceFiles(
         {},
     )
 
-    const resolvedInvalidFiles: Array<
-        INamespace
-    > = Debugger.collectInvalidFiles(Utils.valuesForObject(resolvedNamespaces))
+    const resolvedInvalidFiles: Array<INamespace> = Debugger.collectInvalidFiles(
+        Utils.valuesForObject(resolvedNamespaces),
+    )
 
     if (resolvedInvalidFiles.length > 0) {
         Debugger.printErrors(resolvedInvalidFiles)
@@ -174,9 +174,7 @@ export function thriftProjectFromSourceFiles(
             return acc
         }, {})
 
-        const validatedInvalidFiles: Array<
-            INamespace
-        > = Debugger.collectInvalidFiles(
+        const validatedInvalidFiles: Array<INamespace> = Debugger.collectInvalidFiles(
             Utils.valuesForObject(validatedNamespaces),
         )
 

--- a/src/main/render/apache/struct/create.ts
+++ b/src/main/render/apache/struct/create.ts
@@ -55,9 +55,9 @@ export function renderStruct(
         createFieldAssignment,
     )
 
-    const argsParameter: Array<
-        ts.ParameterDeclaration
-    > = createArgsParameterForStruct(node)
+    const argsParameter: Array<ts.ParameterDeclaration> = createArgsParameterForStruct(
+        node,
+    )
 
     // Build the constructor body
     const ctor: ts.ConstructorDeclaration = createClassConstructor(

--- a/src/main/render/apache/union.ts
+++ b/src/main/render/apache/union.ts
@@ -93,9 +93,9 @@ export function renderUnion(
         undefined, // else
     )
 
-    const argsParameter: Array<
-        ts.ParameterDeclaration
-    > = createArgsParameterForStruct(node)
+    const argsParameter: Array<ts.ParameterDeclaration> = createArgsParameterForStruct(
+        node,
+    )
 
     // let fieldsSet: number = 0;
     const fieldsSet: ts.VariableStatement = createFieldIncrementer()

--- a/src/main/render/shared/includes.ts
+++ b/src/main/render/shared/includes.ts
@@ -13,7 +13,6 @@ import { Resolver } from '../../resolver'
 import { DefinitionType, INamespacePath, IRenderState } from '../../types'
 import { COMMON_IDENTIFIERS } from './identifiers'
 
-
 /**
  * Boolean check for whether a field uses thrift or Int64
  * @param fieldType Field type we are resolving
@@ -26,7 +25,7 @@ function fieldTypeUsesThrift(
     fieldType: FieldType,
     state: IRenderState,
     recursiveResolve: boolean = false,
-    int64Check: boolean = false
+    int64Check: boolean = false,
 ): boolean {
     switch (fieldType.type) {
         case SyntaxType.I64Keyword:
@@ -34,13 +33,28 @@ function fieldTypeUsesThrift(
 
         case SyntaxType.MapType:
             return (
-                fieldTypeUsesThrift(fieldType.keyType, state, recursiveResolve, int64Check) ||
-                fieldTypeUsesThrift(fieldType.valueType, state, recursiveResolve, int64Check)
+                fieldTypeUsesThrift(
+                    fieldType.keyType,
+                    state,
+                    recursiveResolve,
+                    int64Check,
+                ) ||
+                fieldTypeUsesThrift(
+                    fieldType.valueType,
+                    state,
+                    recursiveResolve,
+                    int64Check,
+                )
             )
 
         case SyntaxType.ListType:
         case SyntaxType.SetType:
-            return fieldTypeUsesThrift(fieldType.valueType, state, recursiveResolve, int64Check)
+            return fieldTypeUsesThrift(
+                fieldType.valueType,
+                state,
+                recursiveResolve,
+                int64Check,
+            )
         case SyntaxType.Identifier:
             if (!recursiveResolve) {
                 return false
@@ -77,7 +91,7 @@ function fieldTypeUsesThrift(
                             defFieldType,
                             state,
                             recursiveResolve,
-                            int64Check
+                            int64Check,
                         )
                     )
                 })
@@ -157,7 +171,12 @@ function statementUsesInt64(
             return fieldTypeUsesThrift(statement.fieldType, state, true, true)
 
         case SyntaxType.TypedefDefinition:
-            return fieldTypeUsesThrift(statement.definitionType, state, false, true)
+            return fieldTypeUsesThrift(
+                statement.definitionType,
+                state,
+                false,
+                true,
+            )
 
         default:
             const msg: never = statement

--- a/src/tests/integration/apache/index.spec.ts
+++ b/src/tests/integration/apache/index.spec.ts
@@ -183,7 +183,12 @@ describe('Thrift TypeScript', () => {
 
     it('should correctly call endpoint with maps as parameters', async () => {
         return thriftClient
-            .mapValues(new Map([['key1', 6], ['key2', 5]]))
+            .mapValues(
+                new Map([
+                    ['key1', 6],
+                    ['key2', 5],
+                ]),
+            )
             .then((response: Array<number>) => {
                 assert.deepEqual(response, [6, 5])
             })
@@ -191,11 +196,17 @@ describe('Thrift TypeScript', () => {
 
     it('should correctly call endpoint that returns a map', async () => {
         return thriftClient
-            .listToMap([['key_1', 'value_1'], ['key_2', 'value_2']])
+            .listToMap([
+                ['key_1', 'value_1'],
+                ['key_2', 'value_2'],
+            ])
             .then((response: Map<string, string>) => {
                 assert.deepEqual(
                     response,
-                    new Map([['key_1', 'value_1'], ['key_2', 'value_2']]),
+                    new Map([
+                        ['key_1', 'value_1'],
+                        ['key_2', 'value_2'],
+                    ]),
                 )
             })
     })

--- a/src/tests/integration/thrift/user.thrift
+++ b/src/tests/integration/thrift/user.thrift
@@ -29,7 +29,10 @@ const User USER = {
     "value": "test value"
   },
   "subuser": {
-    "subname": "hello subuser"
+    "subname": "hello subuser",
+    "subsubuser": {
+      "subname": "hello subsubuser"
+    }
   },
   "test": {
     "common": {
@@ -41,8 +44,17 @@ const User USER = {
   }
 }
 
+
+const SubUser SUB_USER = {
+  "subname": "hello",
+  "subsubuser": {
+    "subname": "there"
+  }
+}
+
 struct SubUser {
   1: string subname
+  2: optional SubUser subsubuser
 }
 
 struct User {


### PR DESCRIPTION
Some of these checks do not always need to be recursive. By cleaning
them and removing the unnecessary hack blocks we no longer generate
unused imports

- Prettier fixes
- JSDoc comments
- Updates identifiersForStatements by adding an explicit recursive flag
and removes unnecessary hack. Restructure loop slightly
- Updates includes generator to allow for explicit Int64 vs thrift
checks to avoid unnecessary imports. Also adds explicit recursion flag
because we only need the recursive walk in a single case
- Adds recursive case to user.thrift integration tests