### PR TITLE
Update checks to remove redundancy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Editor Directories
-.vscode/
-
 # Logs
 logs
 *.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Codegen",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run",
+                "codegen:debug",
+                "--scripts-prepend-node-path"
+            ],
+            "port": 9229,
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Codegen UC",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run",
+                "codegen:uc:debug",
+                "--scripts-prepend-node-path"
+            ],
+            "port": 9229,
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        }
+    ]
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -158,9 +158,9 @@ export function thriftProjectFromSourceFiles(
         {},
     )
 
-    const resolvedInvalidFiles: Array<
-        INamespace
-    > = Debugger.collectInvalidFiles(Utils.valuesForObject(resolvedNamespaces))
+    const resolvedInvalidFiles: Array<INamespace> = Debugger.collectInvalidFiles(
+        Utils.valuesForObject(resolvedNamespaces),
+    )
 
     if (resolvedInvalidFiles.length > 0) {
         Debugger.printErrors(resolvedInvalidFiles)
@@ -174,9 +174,7 @@ export function thriftProjectFromSourceFiles(
             return acc
         }, {})
 
-        const validatedInvalidFiles: Array<
-            INamespace
-        > = Debugger.collectInvalidFiles(
+        const validatedInvalidFiles: Array<INamespace> = Debugger.collectInvalidFiles(
             Utils.valuesForObject(validatedNamespaces),
         )
 

--- a/src/main/render/apache/struct/create.ts
+++ b/src/main/render/apache/struct/create.ts
@@ -55,9 +55,9 @@ export function renderStruct(
         createFieldAssignment,
     )
 
-    const argsParameter: Array<
-        ts.ParameterDeclaration
-    > = createArgsParameterForStruct(node)
+    const argsParameter: Array<ts.ParameterDeclaration> = createArgsParameterForStruct(
+        node,
+    )
 
     // Build the constructor body
     const ctor: ts.ConstructorDeclaration = createClassConstructor(

--- a/src/main/render/apache/union.ts
+++ b/src/main/render/apache/union.ts
@@ -93,9 +93,9 @@ export function renderUnion(
         undefined, // else
     )
 
-    const argsParameter: Array<
-        ts.ParameterDeclaration
-    > = createArgsParameterForStruct(node)
+    const argsParameter: Array<ts.ParameterDeclaration> = createArgsParameterForStruct(
+        node,
+    )
 
     // let fieldsSet: number = 0;
     const fieldsSet: ts.VariableStatement = createFieldIncrementer()

--- a/src/main/resolver/identifiersForStatements.ts
+++ b/src/main/resolver/identifiersForStatements.ts
@@ -12,15 +12,30 @@ import { IResolveContext, IResolveResult } from '../types'
 import { resolveIdentifierDefinition } from './resolveIdentifierDefinition'
 import { resolveIdentifierWithAccessor } from './resolveIdentifierWithAccessor'
 
+interface IIdentifiersForFieldTypeConfig {
+    // Is this identifier being resolved in a context where we need to know the underlying type of typedefs?
+    resolveTypedefs?: boolean
+    // This flag toggles whether we need to continue recursing along typedefs and struct defs
+    recursiveResolve?: boolean
+}
+
+/**
+ * Resolve all identifiers used by a given field type
+ * @param fieldType The field type we are checking for identifiers
+ * @param results (MUTATED) result set which will contain all fieldtype identifiers
+ * @param context Resolver context used for finding identifier definitions
+ * @param config Further behavior configuration
+ */
 function identifiersForFieldType(
     fieldType: FunctionType,
     results: Set<string>,
     context: IResolveContext,
-    // Is this identifier being resolved in a context where we need to know the underlying type of typedefs?
-    resolveTypedefs: boolean = false,
+    config: IIdentifiersForFieldTypeConfig = {},
 ): void {
+    const { resolveTypedefs = false, recursiveResolve = false } = config
     switch (fieldType.type) {
         case SyntaxType.Identifier:
+            results.add(fieldType.value)
             if (resolveTypedefs) {
                 const result: IResolveResult = resolveIdentifierDefinition(
                     fieldType,
@@ -33,25 +48,6 @@ function identifiersForFieldType(
                 const definition = result.definition
                 const namespace = result.namespace
 
-                // HACK(josh): If the recursively checked namespace is not part of the current namespace we may
-                // need it. This adds it to the current namespace includes.
-                // This should actually be done at the parser level. We only need to do it here because this is the first
-                // recursive check run.
-                if (
-                    context.currentNamespace.namespace.accessor !==
-                        namespace.namespace.accessor &&
-                    !context.currentNamespace.includedNamespaces[
-                        namespace.namespace.accessor
-                    ]
-                ) {
-                    context.currentNamespace.includedNamespaces[
-                        namespace.namespace.accessor
-                    ] =
-                        context.namespaceMap[
-                            namespace.namespace.accessor
-                        ].namespace
-                }
-
                 if (definition.type === SyntaxType.TypedefDefinition) {
                     identifiersForFieldType(
                         definition.definitionType,
@@ -60,9 +56,10 @@ function identifiersForFieldType(
                     )
                 }
 
-                results.add(fieldType.value)
-
-                if (definition.type === SyntaxType.StructDefinition) {
+                if (
+                    recursiveResolve &&
+                    definition.type === SyntaxType.StructDefinition
+                ) {
                     for (const field of definition.fields) {
                         // HACK(josh): If the definition namespace is not part of an identifier
                         // fieldtype we must stub it in for it to be referenced properly. This is
@@ -82,7 +79,7 @@ function identifiersForFieldType(
                                     defFieldType,
                                     results,
                                     context,
-                                    true,
+                                    config,
                                 )
                             }
                         } else {
@@ -94,8 +91,6 @@ function identifiersForFieldType(
                         }
                     }
                 }
-            } else {
-                results.add(fieldType.value)
             }
             break
 
@@ -160,7 +155,10 @@ export function identifiersForStatements(
                 break
 
             case SyntaxType.ConstDefinition:
-                identifiersForFieldType(next.fieldType, results, context, true)
+                identifiersForFieldType(next.fieldType, results, context, {
+                    recursiveResolve: true,
+                    resolveTypedefs: true,
+                })
                 identifiersForConstValue(next.initializer, results)
                 break
 
@@ -172,12 +170,9 @@ export function identifiersForStatements(
             case SyntaxType.UnionDefinition:
             case SyntaxType.ExceptionDefinition:
                 next.fields.forEach((field: FieldDefinition) => {
-                    identifiersForFieldType(
-                        field.fieldType,
-                        results,
-                        context,
-                        true,
-                    )
+                    identifiersForFieldType(field.fieldType, results, context, {
+                        resolveTypedefs: true,
+                    })
                     identifiersForConstValue(field.defaultValue, results)
                 })
                 break
@@ -193,7 +188,9 @@ export function identifiersForStatements(
                             field.fieldType,
                             results,
                             context,
-                            true,
+                            {
+                                resolveTypedefs: true,
+                            },
                         )
                         identifiersForConstValue(field.defaultValue, results)
                     })
@@ -203,17 +200,16 @@ export function identifiersForStatements(
                             field.fieldType,
                             results,
                             context,
-                            true,
+                            {
+                                resolveTypedefs: true,
+                            },
                         )
                         identifiersForConstValue(field.defaultValue, results)
                     })
 
-                    identifiersForFieldType(
-                        func.returnType,
-                        results,
-                        context,
-                        true,
-                    )
+                    identifiersForFieldType(func.returnType, results, context, {
+                        resolveTypedefs: true,
+                    })
                 })
 
                 break

--- a/src/tests/integration/apache/index.spec.ts
+++ b/src/tests/integration/apache/index.spec.ts
@@ -183,7 +183,12 @@ describe('Thrift TypeScript', () => {
 
     it('should correctly call endpoint with maps as parameters', async () => {
         return thriftClient
-            .mapValues(new Map([['key1', 6], ['key2', 5]]))
+            .mapValues(
+                new Map([
+                    ['key1', 6],
+                    ['key2', 5],
+                ]),
+            )
             .then((response: Array<number>) => {
                 assert.deepEqual(response, [6, 5])
             })
@@ -191,11 +196,17 @@ describe('Thrift TypeScript', () => {
 
     it('should correctly call endpoint that returns a map', async () => {
         return thriftClient
-            .listToMap([['key_1', 'value_1'], ['key_2', 'value_2']])
+            .listToMap([
+                ['key_1', 'value_1'],
+                ['key_2', 'value_2'],
+            ])
             .then((response: Map<string, string>) => {
                 assert.deepEqual(
                     response,
-                    new Map([['key_1', 'value_1'], ['key_2', 'value_2']]),
+                    new Map([
+                        ['key_1', 'value_1'],
+                        ['key_2', 'value_2'],
+                    ]),
                 )
             })
     })

--- a/src/tests/integration/thrift/user.thrift
+++ b/src/tests/integration/thrift/user.thrift
@@ -29,7 +29,10 @@ const User USER = {
     "value": "test value"
   },
   "subuser": {
-    "subname": "hello subuser"
+    "subname": "hello subuser",
+    "subsubuser": {
+      "subname": "hello subsubuser"
+    }
   },
   "test": {
     "common": {
@@ -41,8 +44,17 @@ const User USER = {
   }
 }
 
+
+const SubUser SUB_USER = {
+  "subname": "hello",
+  "subsubuser": {
+    "subname": "there"
+  }
+}
+
 struct SubUser {
   1: string subname
+  2: optional SubUser subsubuser
 }
 
 struct User {


### PR DESCRIPTION
Some of these checks do not always need to be recursive. By cleaning them
and removing the unnecessary hack blocks we no longer generate unused
imports

- Prettier fixes
- JSDoc comments
- Updates identifiersForStatements by adding an explicit recursive flag and
removes unnecessary hack. Restructure loop slightly
- Updates includes generator to allow for explicit Int64 vs thrift checks
to avoid unnecessary imports. Also adds explicit recursion flag because we
only need the recursive walk in a single case
- Adds recursive case to user.thrift integration tests