### PR TITLE
Make typescript a peer dependency of the generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -638,9 +638,10 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+            "version": "3.8.3",
+            "resolved": "https://urbancompass.jfrog.io/urbancompass/api/npm/npm/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha1-QJ64VE6gM1cRIFhp7EWKsQnuEGE=",
+            "dev": true
         },
         "universalify": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
         "@creditkarma/thrift-parser": "^1.2.0",
         "@types/fs-extra": "^7.0.0",
         "fs-extra": "^8.0.1",
-        "glob": "^7.1.2",
-        "typescript": "3.5.x"
+        "glob": "^7.1.2"
     },
     "devDependencies": {
         "@types/chai": "^4.1.5",
@@ -71,6 +70,10 @@
         "thrift": "^0.11.0",
         "tslint": "^5.11.0",
         "tslint-config-prettier": "^1.17.0",
-        "tslint-plugin-prettier": "^2.0.0"
+        "tslint-plugin-prettier": "^2.0.0",
+        "typescript": "^3.8.3"
+    },
+    "peerDependencies": {
+        "typescript": "^3.8.3"
     }
 }


### PR DESCRIPTION
This allows consumers to use a peer installed version of typescript
instead of forcing dependent packages to use the one installed by this
package.